### PR TITLE
Make it work with squash-merge as well

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,13 +15,13 @@ cd $(basename "$GITHUB_REPOSITORY")
 TARGET=origin/$(cat $GITHUB_EVENT_PATH | jq -r '.pull_request.base.ref')
 echo "Target branch: $TARGET"
 
-CHANGES=$(git log $TARGET.. --merges --pretty=format:'* [ ] %s' \
-   | sed -E 's/Merge pull request (.*) from .*/\1 /g')
+CHANGES=$(git log $TARGET.. --first-parent --pretty=format:'%s' \
+   | sed -E 's/.*(#[0-9]+).*/\* \[ \] \1/g')
 echo "Changes: "
 echo "$CHANGES"
 
 # Ignore branch merges
-VALID_COMMENTS=$(echo "$CHANGES" | grep -v -- 'Merge branch ')
+VALID_COMMENTS=$(echo "$CHANGES" | grep '^\* \[ \] #[0-9]\+$')
 echo "Valid comments: "
 echo "$VALID_COMMENTS"
 


### PR DESCRIPTION
## Summary
The original script did not work as expected when the PR was squash-merged.
I have modified the script to work for both commit-merge and squash-merge.

### Detail
- Use `--first-parent` option instead of `--merges` option.
  - This allows us to see only the parent commits for each branch that has been merged. ([ref](https://git-scm.com/docs/git-describe))
    - Commits from squash merges can also be picked up
    - We can also ignore mid-branch merges
- Since squash-merge has a different commit message than commit-merge, I set `sed` regex condition loosely (just pick `#xxx`).