### PR TITLE
Support non-default branch as source

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,8 +14,10 @@ cd $(basename "$GITHUB_REPOSITORY")
 
 TARGET=origin/$(cat $GITHUB_EVENT_PATH | jq -r '.pull_request.base.ref')
 echo "Target branch: $TARGET"
+SOURCE=origin/$(cat $GITHUB_EVENT_PATH | jq -r '.pull_request.head.ref')
+echo "Source branch: $SOURCE"
 
-CHANGES=$(git log $TARGET.. --first-parent --pretty=format:'%s' \
+CHANGES=$(git log $TARGET..$SOURCE --first-parent --pretty=format:'%s' \
    | sed -E 's/.*(#[0-9]+).*/\* \[ \] \1/g')
 echo "Changes: "
 echo "$CHANGES"


### PR DESCRIPTION
The original implementation expects the head of a PR is always the default branch.

This doesn't work on several situations, such as patching and multiple development branches.