### PR TITLE
Bump ruby version to 3.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.0-alpine
+FROM ruby:3.0.2-alpine
 
 RUN apk update && \
     apk upgrade && \


### PR DESCRIPTION
This PR updates the ruby version from 2.7 (which is already EOL) to 3.0.2.

This also fixes #63 