### PR TITLE
fix: error on no merge commits

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,7 @@ echo "Changes: "
 echo "$CHANGES"
 
 # Ignore branch merges
-VALID_COMMENTS=$(echo "$CHANGES" | grep '^\* \[ \] #[0-9]\+$')
+VALID_COMMENTS=$(echo "$CHANGES" | grep '^\* \[ \] #[0-9]\+$' || echo "")
 echo "Valid comments: "
 echo "$VALID_COMMENTS"
 


### PR DESCRIPTION
This commit prevents the workflow from causing an error
when git-log does not produce lines matching with `#[0-9]+`.

Previous implementation caused an error on grep 
when there's no `#[0-9]+` line, since grep exits with 1 when no matching input provided.

Test run: https://github.com/mandaiy/list-merged-pull-requests/actions/runs/7472414521